### PR TITLE
refactor(StartGame): configura mapa y celda de inicio,  y personaje player

### DIFF
--- a/src/runner_3d/gd/one_shot/start_game/start_game.gd
+++ b/src/runner_3d/gd/one_shot/start_game/start_game.gd
@@ -1,5 +1,30 @@
 class_name StartGame extends OneShot
 
+@export var _player_ref: EntityReference
+@export var _start_spawn_point_ref: EntityReference
+@export var _game_state_ref: EntityReference
+
 
 func _on_first_start() -> void:
-	print("juego iniciado")
+	var game_state: GameState = get_game_state()
+	var player: Character = get_player()
+	var start_spawn_point: SpawnPoint = get_start_spawn_point()
+	var start_cell: Cell = start_spawn_point.get_cell()
+	var start_map: Map = start_cell.get_map()
+
+	player.move_to_spawn_point(start_spawn_point)
+	game_state.set_player(player)
+	game_state.set_current_cell(start_cell)
+	game_state.set_current_map(start_map)
+
+
+func get_start_spawn_point() -> SpawnPoint:
+	return _start_spawn_point_ref.get_reference()
+
+
+func get_player() -> Character:
+	return _player_ref.get_reference()
+
+
+func get_game_state() -> GameState:
+	return _game_state_ref.get_reference()

--- a/src/runner_3d/gd/one_shot/start_game/start_game.tscn
+++ b/src/runner_3d/gd/one_shot/start_game/start_game.tscn
@@ -1,7 +1,20 @@
-[gd_scene load_steps=2 format=3 uid="uid://b6x7p5q33l5lc"]
+[gd_scene load_steps=3 format=3 uid="uid://b6x7p5q33l5lc"]
 
 [ext_resource type="Script" path="res://src/runner_3d/gd/one_shot/start_game/start_game.gd" id="1_7gnm7"]
+[ext_resource type="Script" path="res://addons/mod_manager/src/data/entity_reference.gd" id="2_ynaco"]
 
-[node name="StartGame" type="Node"]
+[node name="StartGame" type="Node" node_paths=PackedStringArray("_player_ref", "_start_spawn_point_ref", "_game_state_ref")]
 process_mode = 4
 script = ExtResource("1_7gnm7")
+_player_ref = NodePath("PlayerRef")
+_start_spawn_point_ref = NodePath("StartSpawnPointRef")
+_game_state_ref = NodePath("GameStateRef")
+
+[node name="PlayerRef" type="Node" parent="."]
+script = ExtResource("2_ynaco")
+
+[node name="StartSpawnPointRef" type="Node" parent="."]
+script = ExtResource("2_ynaco")
+
+[node name="GameStateRef" type="Node" parent="."]
+script = ExtResource("2_ynaco")

--- a/test/runner_3d/gd/one_shot/start_game_test/start_game_test.gd
+++ b/test/runner_3d/gd/one_shot/start_game_test/start_game_test.gd
@@ -6,10 +6,63 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = "res://src/runner_3d/gd/one_shot/start_game/start_game.gd"
-const START_GAME = preload("res://src/runner_3d/gd/one_shot/start_game/start_game.tscn")
 
 
 func test__on_first_start() -> void:
-	var spy_start_game := spy(auto_free(START_GAME.instantiate())) as StartGame
-	spy_start_game._on_game_event_started()
-	verify(spy_start_game, 1)._on_first_start()
+	var start_game: StartGame = auto_free(StartGame.new()) as StartGame
+	var start_spawn_point_ref: EntityReference = mock(EntityReference) as EntityReference
+	start_game._start_spawn_point_ref = start_spawn_point_ref
+	var player_ref: EntityReference = mock(EntityReference) as EntityReference
+	start_game._player_ref = player_ref
+	var game_state_ref: EntityReference = mock(EntityReference) as EntityReference
+	start_game._game_state_ref = game_state_ref
+
+	var character: Character = mock(Character) as Character
+	do_return(character).on(player_ref).get_reference()
+
+	var spawn_point: SpawnPoint = mock(SpawnPoint) as SpawnPoint
+	do_return(spawn_point).on(start_spawn_point_ref).get_reference()
+	var cell: Cell = mock(Cell) as Cell
+	do_return(cell).on(spawn_point).get_cell()
+	var map: Map = auto_free(Map.new())
+	do_return(map).on(cell).get_map()
+
+	var game_state: GameState = spy(auto_free(GameState.new())) as GameState
+	game_state._cell_ref = mock(EntityReference)
+	game_state._map_ref = mock(EntityReference)
+	game_state._player_ref = mock(EntityReference)
+	do_return(game_state).on(game_state_ref).get_reference()
+
+	start_game._on_first_start()
+
+	verify(character, 1).move_to_spawn_point(spawn_point)
+	verify(game_state, 1).set_player(character)
+	verify(game_state, 1).set_current_cell(cell)
+	verify(game_state, 1).set_current_map(map)
+
+
+func test_get_start_spawn_point() -> void:
+	var start_game: StartGame = auto_free(StartGame.new()) as StartGame
+	var start_spawn_point_ref: EntityReference = mock(EntityReference) as EntityReference
+	start_game._start_spawn_point_ref = start_spawn_point_ref
+	var spawn_point: SpawnPoint = auto_free(SpawnPoint.new())
+	do_return(spawn_point).on(start_spawn_point_ref).get_reference()
+	assert_object(start_game.get_start_spawn_point()).is_same(spawn_point)
+
+
+func test_get_player() -> void:
+	var start_game: StartGame = auto_free(StartGame.new()) as StartGame
+	var player_ref: EntityReference = mock(EntityReference) as EntityReference
+	start_game._player_ref = player_ref
+	var character: Character = auto_free(Character.new()) as Character
+	do_return(character).on(player_ref).get_reference()
+	assert_object(start_game.get_player()).is_same(character)
+
+
+func test_get_game_state() -> void:
+	var start_game: StartGame = auto_free(StartGame.new()) as StartGame
+	var game_state_ref: EntityReference = mock(EntityReference) as EntityReference
+	start_game._game_state_ref = game_state_ref
+	var game_state: GameState = auto_free(GameState.new()) as GameState
+	do_return(game_state).on(game_state_ref).get_reference()
+	assert_object(start_game.get_game_state()).is_same(game_state)

--- a/test/runner_3d/mods/runner_3d_test.gd
+++ b/test/runner_3d/mods/runner_3d_test.gd
@@ -10,3 +10,24 @@ func test_runner_3d_cfg_is_valid() -> void:
 	var cfg: ConfigFile = ConfigFile.new()
 	var state: int = cfg.load(RUNNER_3D_PATH)
 	assert_int(state).is_equal(OK)
+
+
+func test_runner_3d_cfg_has_the_entities() -> void:
+	var entities: Dictionary = {
+		"GameState": "res://src/runner_3d/entities/game_state.tscn",
+		"StartGame": "res://src/runner_3d/entities/start_game.tscn",
+		"MapSmokeTests": "res://src/runner_3d/entities/map_smoke_tests.tscn"
+	}
+	var cfg: ConfigFile = ConfigFile.new()
+	var state: int = cfg.load(RUNNER_3D_PATH)
+	assert_int(state).is_equal(OK)
+	var mod: Mod = Mod.new(cfg)
+	for key: String in entities:
+		var path: String = entities[key]
+		var ent: Dictionary = mod.get_entities().get(key)
+		assert_object(ent).is_not_null()
+		var scene_path: String = ent.get(Entity.KEY_SCENE_FILE_PATH, "")
+		assert_str(scene_path).is_not_empty()
+		assert_str(scene_path).is_equal(path)
+		var scene: PackedScene = load(scene_path)
+		assert_object(scene).is_not_null()


### PR DESCRIPTION
## Description
StartGame configura mapa de inicio, celda de inicio y personaje player.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## Checklist
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
